### PR TITLE
Display cash and bank sums separately in orders

### DIFF
--- a/src/components/SortableItem.tsx
+++ b/src/components/SortableItem.tsx
@@ -85,7 +85,16 @@ const SortableItem = ({
       >
         <div className="flex justify-between">
           <h2 className="text-xs">{task.client_name}</h2>
-          <p className="text-xs">{task.sum} ₾</p>
+          {
+            task.sumcash === task.sum ? (
+              <p className="text-xs text-blue-700 font-bold">{task.sum} ₾</p>
+            ) : (
+              <div className="flex gap-2">
+                <p className="text-xs text-red-500 font-bold">{task.sumcash} ₾</p>
+                <p className="text-xs text-blue-700 font-bold">{task.sum} ₾</p>
+              </div>
+            )
+          }
         </div>
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-1">

--- a/src/components/order page components/SameClientsOrders.tsx
+++ b/src/components/order page components/SameClientsOrders.tsx
@@ -4,6 +4,7 @@ interface SameClientsOrdersProps {
   selectedOrdersList: {
     tracking_code: string;
     sum: number;
+    sumcash: number;
     client_address: string;
     places?: any[];
     parcel_with_return?: boolean;
@@ -75,7 +76,22 @@ if (showReturnParcels) {
               </div>
               <div className="flex justify-between items-center">
                 <span className="font-base text-sm">{t("sum")} :</span>
-                <span className="font-base text-sm">{order.sum} ₾</span>
+                { order.sumcash == order.sum ? (
+                  <span className="font-bold text-sm text-blue-700">{order.sum} ₾</span>
+                ) : (
+                <div>
+                  <div className="flex gap-2">
+                    <span className="font-bold text-sm text-blue-700">{t("Cash2")}</span>
+                    <span className="font-bold text-sm text-blue-700">{order.sumcash} ₾</span>
+                  </div>
+                  <div className="flex gap-2">
+                    <span className="font-bold text-sm text-blue-700">{t("Bank")}</span>
+                    <span className="font-bold text-sm text-blue-700">{order.sum} ₾</span>
+                  </div>
+                </div>
+                )
+
+                }
               </div>
             </div>
           </li>

--- a/src/hooks/order page hooks/useOrder.ts
+++ b/src/hooks/order page hooks/useOrder.ts
@@ -5,6 +5,7 @@ const useOrder = (
   selectedOrdersList: {
     tracking_code: string;
     sum: number;
+    sumcash?: number;
     places?: { tracking_code: string; sum: number }[];
   }[]
 ) => {
@@ -50,13 +51,23 @@ const useOrder = (
     }));
   };
 
-  const allOrders = selectedOrdersList.flatMap((order) =>
-    order.places && order.places.length > 0 ? order.places : [order]
+  const allOrders: { tracking_code: string; sum: number; sumcash?: number }[] = selectedOrdersList.flatMap((order) =>
+    order.places && order.places.length > 0
+      ? order.places.map((place) => ({
+          ...place,
+          sumcash: order.sumcash, 
+        }))
+      : [order]
   );
 
   const totalSum = matchedOrder ? matchedOrder.sum :  allOrders
     .filter((order) => selectedOrders[order.tracking_code])
     .reduce((sum, order) => sum + order.sum, 0)
+    .toFixed(2) ;
+
+  const totalSumCash = matchedOrder ? matchedOrder.sumcash :  allOrders
+    .filter((order) => selectedOrders[order.tracking_code])
+    .reduce((sum, order) => sum + (order.sumcash ?? 0), 0)
     .toFixed(2) ;
 
   const totalQuantity = allOrders.filter(
@@ -67,6 +78,7 @@ const useOrder = (
     selectedOrders,
     setSelectedOrders,
     totalSum,
+    totalSumCash,
     totalQuantity,
     handleCheckboxChange,
   };

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -1,6 +1,7 @@
 {
   "General Information": "General Information",
   "Cash": "Cash",
+  "Cash2": "Cash",
   "Bank": "Bank",
   "Total Amount": "Total Amount",
   "Receipt orders": "Receipt orders",

--- a/src/i18n/locales/ge/translation.json
+++ b/src/i18n/locales/ge/translation.json
@@ -1,6 +1,7 @@
 {
   "General Information": "ზოგადი ინფორმაცია",
   "Cash": "ნაღდი ფული",
+  "Cash2": "ნაღდი",
   "Bank": "ბარათი",
   "Total Amount": "ჯამური თანხა",
   "Receipt orders": "შეკვეთების გამოტანა",

--- a/src/i18n/locales/ru/translation.json
+++ b/src/i18n/locales/ru/translation.json
@@ -1,6 +1,7 @@
 {
   "General Information": "Общая информация",
   "Cash": "Наличные",
+  "Cash2": "Наличные",
   "Bank": "Карта",
   "Total Amount": "Общая сумма",
   "Receipt orders": "Заказы на получение",

--- a/src/pages/OrderPage.tsx
+++ b/src/pages/OrderPage.tsx
@@ -21,6 +21,7 @@ const OrderPage = () => {
     setSelectedOrders,
     selectedOrders,
     totalSum,
+    totalSumCash,
     totalQuantity,
     handleCheckboxChange,
   } = useOrder(selectedOrdersList);
@@ -126,9 +127,25 @@ const OrderPage = () => {
               </span>
             </div>
             {(order.Status !== "Accepted" || order?.places) && (
-              <div className="p-1 flex justify-between">
+              <div className="p-1 flex justify-between items-center">
                 <span className="font-base text-sm">{t("sum")} :</span>
-                <span className="font-base text-sm">{order.sum} ₾</span>
+                { order.sumcash == order.sum ? (
+                  <span className="font-bold text-sm text-blue-700">{order.sum} ₾</span>
+                ) : (
+                <div>
+                  <div className="flex gap-2">
+                    <span className="font-bold text-sm text-blue-700">{t("Cash2")}</span>
+                    <span className="font-bold text-sm text-blue-700">{order.sumcash} ₾</span>
+                  </div>
+                  <div className="flex gap-2">
+                    <span className="font-bold text-sm text-blue-700">{t("Bank")}</span>
+                    <span className="font-bold text-sm text-blue-700">{order.sum} ₾</span>
+                  </div>
+                </div>
+                )
+
+                }
+                
               </div>
             )}
             <div className="p-1 flex justify-between">
@@ -176,9 +193,18 @@ const OrderPage = () => {
                   <span>{t("Total quantity")} :</span>
                   <span className="font-medium">{totalQuantity}</span>
                 </div>
-                <div className="p-1 flex justify-between">
+                <div className="flex justify-between items-center">
                   <span>{t("Total amount")} :</span>
-                  <span className="font-medium">{totalSum} ₾</span>
+                  {
+                    totalSumCash === totalSum ? (
+                      <span className="font-medium text-s text-blue-700">{totalSum} ₾</span>
+                    ) : (
+                    <div className="flex flex-col">
+                      <span className="font-medium text-xs text-blue-700">{t("Cash2")} {totalSumCash} ₾</span>
+                      <span className="font-medium text-xs text-blue-700">{t("Bank")} {totalSum} ₾</span>
+                    </div>
+                    )
+                  }
                 </div>
                 <div className="flex space-x-4">
                   <Button


### PR DESCRIPTION
Updated order components and hooks to show separate cash and bank sums when they differ, both for individual orders and totals. Added new translation keys for 'Cash2' in all supported languages. This improves clarity for users when orders are paid partially in cash and partially by bank.